### PR TITLE
Add Jest test suite for ponerBandera

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "tarea-6",
+  "version": "1.0.0",
+  "private": true,
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^23.0.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tests/tarea5.test.js
+++ b/tests/tarea5.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+function loadPonerBandera(dom) {
+  const code = fs.readFileSync(path.resolve(__dirname, '../js/tarea5.js'), 'utf8');
+  const context = { window: dom.window, document: dom.window.document };
+  vm.createContext(context);
+  vm.runInContext(code, context);
+  return context.ponerBandera;
+}
+
+describe('ponerBandera', () => {
+  let dom;
+  let ponerBandera;
+
+  beforeEach(() => {
+    dom = new JSDOM(`
+      <select id="listaBanderas">
+        <option value="Guatemala">Guatemala</option>
+        <option value="India">India</option>
+        <option value="Bajos">Bajos</option>
+        <option value="Suecia">Suecia</option>
+        <option value="Suiza">Suiza</option>
+      </select>
+      <article id="ejercicio1"></article>
+      <article id="ejercicio2"></article>
+      <article id="ejercicio3"></article>
+      <article id="ejercicio4"></article>
+      <article id="ejercicio5"></article>
+    `);
+    ponerBandera = loadPonerBandera(dom);
+  });
+
+  function getDisplays(document) {
+    return [1,2,3,4,5].map(i => document.getElementById(`ejercicio${i}`).style.display);
+  }
+
+  test('shows Guatemala section only', () => {
+    const { document } = dom.window;
+    document.getElementById('listaBanderas').value = 'Guatemala';
+    ponerBandera();
+    expect(getDisplays(document)).toEqual(['block','none','none','none','none']);
+  });
+
+  test('shows India section only', () => {
+    const { document } = dom.window;
+    document.getElementById('listaBanderas').value = 'India';
+    ponerBandera();
+    expect(getDisplays(document)).toEqual(['none','block','none','none','none']);
+  });
+});


### PR DESCRIPTION
## Summary
- add `package.json` with Jest and jsdom dev dependencies
- configure npm `test` script to run Jest
- create `tarea5.test.js` with jsdom DOM setup and tests for `ponerBandera`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423c319c4c832698344b8f25798e4e