### PR TITLE
Fix label for attribute typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <h2>José Alberto Rodriguez Alvarado</h2>
         <fieldset>
             <legend>Seleccione una bandera a visualizar</legend>
-            <label for="listaBanbderas">Seleccione bandera:</label>
+            <label for="listaBanderas">Seleccione bandera:</label>
             <select id="listaBanderas" onchange="ponerBandera()">
                 <option value="Guatemala">Guatemala</option>
                 <option value="India">Niger e India</option>


### PR DESCRIPTION
## Summary
- correct `for` attribute in index.html label from `listaBanbderas` to `listaBanderas`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423bb501c483269ed51ea115153737